### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ can be passed to the API:
 
 ```javascript
 .pipe(closure({
+  language: 'ECMASCRIPT5',
   compilation_level: 'WHITESPACE_ONLY'
 }))
 ```


### PR DESCRIPTION
The language option when using the -jar requires `language_in`, but a different key is required when using this library.